### PR TITLE
JMK_85: support for Freelancer Profile Creation with Profile Photo

### DIFF
--- a/src/Pages/Freelancer/Profile/ProfileReview.test.tsx
+++ b/src/Pages/Freelancer/Profile/ProfileReview.test.tsx
@@ -3,10 +3,9 @@ import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import axios from "axios";
 import { BrowserRouter } from "react-router-dom";
-import ProfileReview from "./ProfileReview";
-
-// Import your SignupProvider from its actual path
-import { SignupProvider } from "../Signup/SignupContext";
+import ProfileReview from "../../../pages/Freelancer/Profile/ProfileReview";
+import { SignupProvider } from "../../../pages/Freelancer/Signup/SignupContext";
+import config from "../../../config/indexConfig";
 
 jest.mock("axios");
 const mockedAxios = axios as jest.Mocked<typeof axios>;
@@ -49,7 +48,7 @@ describe("ProfileReview Component", () => {
     type PayloadType = { freelancerId: string; name: string; [key: string]: unknown };
     const calledPayload = mockedAxios.post.mock.calls[0][1] as PayloadType;
 
-    expect(calledUrl).toBe("http://localhost:8081/api/freelancer/create_profile");
+    expect(calledUrl).toBe(config.baseURLs.users + config.endpoints.createFreelancerProfile);
     expect(calledPayload.freelancerId).toBe("mock-user-123");
     expect(calledPayload.name).toBeDefined();
 

--- a/src/Pages/Freelancer/Profile/ProfileReview.tsx
+++ b/src/Pages/Freelancer/Profile/ProfileReview.tsx
@@ -97,6 +97,14 @@ const ProfileReview = () => {
         profilePhotoS3Key: s3Key, // Set S3 key or null
         profileStatus: "PENDING",
         timezone: timezone,
+        profileVisibility: "PRIVATE",
+        categoriesDTO: [
+    {
+      categoryId: 1,
+      category: "Accounting & Consulting",
+      speciality: "Personal & Professional Coaching",
+    },
+        ]
       };
 
       await ProfileService.createFreelancerProfile(payload);

--- a/src/Pages/Freelancer/Profile/ProfileReview.tsx
+++ b/src/Pages/Freelancer/Profile/ProfileReview.tsx
@@ -1,10 +1,10 @@
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useSignup } from "../Signup/SignupContext";
-import axios from "axios";
 import { getMockUserId, initMockUser } from "../../../utils/initUser";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faAddressCard } from "@fortawesome/free-solid-svg-icons";
+import { ProfileService, ProfilePayload } from "../../../services/ProfileService";
 
 const ProfileReview = () => {
   const { signupData } = useSignup();
@@ -27,6 +27,9 @@ const ProfileReview = () => {
     if (loading) return;
     setLoading(true);
 
+    let s3Key = null;
+    const photoFile = signupData.photo;
+
     try {
       const userId = localStorage.getItem("user_id");
       if (!userId) {
@@ -35,7 +38,21 @@ const ProfileReview = () => {
         return;
       }
 
-      const payload = {
+      if (photoFile) {
+        try {
+          // 1. Get presigned URL
+          const { uploadUrl, s3Key: returnedS3Key } = await ProfileService.getPresignedUrl(userId, photoFile.type);
+          if (!uploadUrl) throw new Error("No uploadUrl returned from backend");
+          // 2. Upload to S3
+          await ProfileService.uploadPhotoToS3(uploadUrl, photoFile);
+          s3Key = returnedS3Key;
+        } catch (error) {
+          alert("Profile photo is not uploaded.");
+          s3Key = null;
+        }
+      }
+
+      const payload: ProfilePayload = {
         freelancerId: userId,
         name: signupData.name || "",
         title: signupData.title?.trim() || "",
@@ -71,27 +88,18 @@ const ProfileReview = () => {
             title: job.title,
             description: job.description,
             budget_type: job.budget_type,
-            fixed_price: job.fixed_price,
-            hourly_min_rate: job.hourly_min_rate,
-            hourly_max_rate: job.hourly_max_rate,
+            fixed_price: job.fixed_price ? Number(job.fixed_price) : 0,
+            hourly_min_rate: job.hourly_min_rate ? Number(job.hourly_min_rate) : 0,
+            hourly_max_rate: job.hourly_max_rate ? Number(job.hourly_max_rate) : 0,
             project_duration: job.project_duration,
             experience_level: job.experience_level,
           })) || [],
-        profilePhotoURL: "sample_url",
+        profilePhotoS3Key: s3Key, // Set S3 key or null
         profileStatus: "PENDING",
         timezone: timezone,
       };
 
-      await axios.post(
-        "http://localhost:8081/api/freelancer/create_profile",
-        payload,
-        {
-          headers: {
-            "Content-Type": "application/json",
-          },
-        }
-      );
-
+      await ProfileService.createFreelancerProfile(payload);
       alert("Profile published successfully!");
       navigate("/dashboard");
     } catch (error) {

--- a/src/config/commonConfig.ts
+++ b/src/config/commonConfig.ts
@@ -9,6 +9,11 @@ const common = {
     enableNewUI: false,
     loggingEnabled: true,
   },
+  endpoints: {
+    presignedUpload: '/api/presigned_url/upload',
+    createFreelancerProfile: '/api/freelancer/create_profile',
+    // ...other endpoints...
+  },
 };
 
 export default common;

--- a/src/services/ProfileService.test.ts
+++ b/src/services/ProfileService.test.ts
@@ -1,0 +1,91 @@
+import axios from "axios";
+import { ProfileService, ProfilePayload } from "./ProfileService";
+
+// Mock axios properly
+jest.mock("axios");
+const mockedAxios = axios as jest.MockedFunction<typeof axios> & {
+  get: jest.MockedFunction<typeof axios.get>;
+  post: jest.MockedFunction<typeof axios.post>;
+  put: jest.MockedFunction<typeof axios.put>;
+};
+
+describe("ProfileService", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("getPresignedUrl", () => {
+    it("should call axios.get with correct params and return data", async () => {
+      const mockData = { uploadUrl: "url", s3Key: "key" };
+      mockedAxios.get.mockResolvedValueOnce({ data: mockData });
+      
+      const result = await ProfileService.getPresignedUrl("user123", "image/png");
+      
+      expect(mockedAxios.get).toHaveBeenCalledWith(
+        "http://localhost:8081/api/presigned_url/upload",
+        { params: { userId: "user123", contentType: "image/png" } }
+      );
+      expect(result).toEqual(mockData);
+    });
+  });
+
+  describe("uploadPhotoToS3", () => {
+    it("should call axios.put with correct params and resolve true", async () => {
+      const file = new File(["dummy content"], "photo.png", { type: "image/png" });
+      mockedAxios.put.mockResolvedValueOnce({});
+      
+      const result = await ProfileService.uploadPhotoToS3("presigned-url", file);
+      
+      expect(mockedAxios.put).toHaveBeenCalledWith(
+        "presigned-url",
+        file,
+        { headers: { "Content-Type": "image/png" } }
+      );
+      expect(result).toBe(true);
+    });
+
+    it("should retry and throw error after max retries", async () => {
+      const file = new File(["dummy content"], "photo.png", { type: "image/png" });
+      mockedAxios.put.mockRejectedValue(new Error("fail"));
+      
+      await expect(ProfileService.uploadPhotoToS3("presigned-url", file, 2)).rejects.toThrow("fail");
+      expect(mockedAxios.put).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("createFreelancerProfile", () => {
+    it("should call axios.post with correct url, payload, and headers", async () => {
+      const payload: ProfilePayload = {
+        freelancerId: "user123",
+        name: "Test User",
+        title: "Title",
+        bio: "Bio",
+        hourlyRate: 10,
+        city: "City",
+        state: "State",
+        country: "Country",
+        postalCode: "12345",
+        address: "Address",
+        phoneNumber: "1234567890",
+        isAbcMember: false,
+        certificates: [],
+        education: [],
+        jobs: [],
+        profilePhotoS3Key: null,
+        profileStatus: "PENDING",
+        timezone: "Asia/Kolkata",
+      };
+      
+      mockedAxios.post.mockResolvedValueOnce({ data: { message: "ok" } });
+      
+      const result = await ProfileService.createFreelancerProfile(payload);
+      
+      expect(mockedAxios.post).toHaveBeenCalledWith(
+        "http://localhost:8081/api/freelancer/create_profile",
+        payload,
+        { headers: { "Content-Type": "application/json" } }
+      );
+      expect(result.data).toEqual({ message: "ok" });
+    });
+  });
+});

--- a/src/services/ProfileService.ts
+++ b/src/services/ProfileService.ts
@@ -1,0 +1,83 @@
+import axios from "axios";
+import config from "../config/indexConfig";
+
+export interface Certificate {
+  certificateName: string;
+  issuedBy: string;
+  issueDate: string;
+  expiryDate?: string;
+  credentialUrl?: string;
+  freelancerId?: string;
+}
+
+export interface Education {
+  institute: string;
+  degree: string;
+  start_year: string;
+  end_year?: string;
+  description?: string;
+  freelancerId?: string;
+}
+
+export interface JobExperience {
+  title: string;
+  description: string;
+  budget_type: string;
+  fixed_price?: number;
+  hourly_min_rate?: number;
+  hourly_max_rate?: number;
+  project_duration?: string;
+  experience_level?: string;
+}
+
+export interface ProfilePayload {
+  freelancerId: string;
+  name: string;
+  title: string;
+  bio: string;
+  hourlyRate: number;
+  city: string;
+  state: string;
+  country: string;
+  postalCode: string;
+  address: string;
+  phoneNumber: string;
+  isAbcMember: boolean;
+  certificates: Certificate[];
+  education: Education[];
+  jobs: JobExperience[];
+  profilePhotoS3Key: string | null;
+  profileStatus: string;
+  timezone: string;
+}
+
+export class ProfileService {
+  static async getPresignedUrl(userId: string, contentType: string) {
+    const url = config.baseURLs.users + config.endpoints.presignedUpload;
+    const { data } = await axios.get(url, {
+      params: { userId, contentType },
+    });
+    return data;
+  }
+
+  static async uploadPhotoToS3(presignedUrl: string, file: File, retries = 3) {
+    for (let attempt = 1; attempt <= retries; attempt++) {
+      try {
+        await axios.put(presignedUrl, file, {
+          headers: { "Content-Type": file.type },
+        });
+        return true;
+      } catch (error) {
+        if (attempt === retries) throw error;
+      }
+    }
+    return false;
+  }
+
+  static async createFreelancerProfile(payload: ProfilePayload) {
+    const url = config.baseURLs.users + config.endpoints.createFreelancerProfile;
+    return axios.post(url, payload, {
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+}

--- a/src/services/ProfileService.ts
+++ b/src/services/ProfileService.ts
@@ -30,6 +30,12 @@ export interface JobExperience {
   experience_level?: string;
 }
 
+export interface CategoryDTO {
+  categoryId: number; // @NotNull(message = "CategoryId cannot be null")
+  category?: string;
+  speciality?: string;
+}
+
 export interface ProfilePayload {
   freelancerId: string;
   name: string;
@@ -49,6 +55,8 @@ export interface ProfilePayload {
   profilePhotoS3Key: string | null;
   profileStatus: string;
   timezone: string;
+  profileVisibility: string;
+  categoriesDTO: CategoryDTO[];
 }
 
 export class ProfileService {

--- a/src/utils/mockUsers.ts
+++ b/src/utils/mockUsers.ts
@@ -8,17 +8,17 @@ export interface MockUser {
   
   export const mockUsers: MockUser[] = [
     {
-      id: "39f89cc0-2df7-4bb6-b503-09cb2c20616d",
+      id: "2571a168-62d2-405b-bcb0-08c87cf1162d",
       name: "Ishmeet Singh",
       email: "ishmeetsingh@gmail.com",
     },
     {
-      id: "88033018-f0aa-44ff-9678-741b37dac853",
+      id: "2571a168-62d2-405b-bcb0-08c87cf1162d",
       name: "Ishita Sharma",
       email: "ishita@example.com",
     },
     {
-      id: "c19c0442-246f-4c1d-9129-9800dc174cb8",
+      id: "2571a168-62d2-405b-bcb0-08c87cf1162d",
       name: "Kunal Verma",
       email: "kunal@example.com",
     },

--- a/src/utils/mockUsers.ts
+++ b/src/utils/mockUsers.ts
@@ -8,17 +8,17 @@ export interface MockUser {
   
   export const mockUsers: MockUser[] = [
     {
-      id: "2571a168-62d2-405b-bcb0-08c87cf1162d",
+      id: "73de5765-240c-4619-a45f-dedc037fb4a3",
       name: "Ishmeet Singh",
       email: "ishmeetsingh@gmail.com",
     },
     {
-      id: "2571a168-62d2-405b-bcb0-08c87cf1162d",
+      id: "73de5765-240c-4619-a45f-dedc037fb4a3",
       name: "Ishita Sharma",
       email: "ishita@example.com",
     },
     {
-      id: "2571a168-62d2-405b-bcb0-08c87cf1162d",
+     id: "73de5765-240c-4619-a45f-dedc037fb4a3",
       name: "Kunal Verma",
       email: "kunal@example.com",
     },


### PR DESCRIPTION
### [JMK_85:](https://punjabskillsbank.atlassian.net/browse/JMK-85)

## 📤 Profile Photo Upload and Freelancer Profile Creation Flow

### 🔄 Flow Summary

- When a user hits **Submit** on the frontend:
  - A `GET` request is made to `PresignedUrlController` with the following query parameters:
    - `freelancerId`
    - `contentType` of the uploaded image

- **Backend Response:**
  - The backend returns a `PresignedUrlResponse` containing:
    - `presignedUploadUrl`
    - `s3Key`

- **Upload to S3:**
  - The method `ProfileService.uploadToS3(presignedUrl, photo)` is called.
  - This method attempts to upload the image to S3:
    - It retries the upload up to **3 times** in case of failure.
    - On successful upload, it sets the `profilePhotoS3Key` in the payload.
    - If all retries fail, it throws an error and keeps `profilePhotoS3Key` as `null`.

- **Final Save Operation:**
  - A `POST` request is made to `FreelancerProfileController` using `ProfileService`, sending the final payload (with or without the `profilePhotoS3Key` based on upload success).

---

> **🔔 Note:** Upload failures are retried up to 3 times. If all attempts fail, the profile photo is skipped, but the rest of the profile payload is still sent to the backend.
